### PR TITLE
feat: add http retries, user-agent, and correlation id

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,32 @@ try {
 const client = new PolymarketUS({
   keyId: 'your-key-id',
   secretKey: 'your-secret-key',
-  timeout: 30000,  // Request timeout in ms (default: 30000)
+  timeout: 30000,   // Request timeout in ms (default: 30000)
+  maxRetries: 2,    // Automatic retries for idempotent requests (default: 2)
 });
+```
+
+### Retries & reliability
+
+Idempotent requests (`GET`, `DELETE`) are retried automatically on transient
+failures — network errors, timeouts, and `408`/`409`/`429`/`5xx` responses —
+using exponential backoff with jitter. Non-idempotent requests such as order
+placement are **never** retried automatically, so a network blip cannot submit a
+duplicate order. Set `maxRetries: 0` to disable retries.
+
+Every request sends a `User-Agent` and a generated `poly-correlation-id` so
+failures can be traced. The correlation id is attached to raised errors:
+
+```typescript
+import { APIError } from 'polymarket-us';
+
+try {
+  await client.account.balances();
+} catch (error) {
+  if (error instanceof APIError) {
+    console.error(error.status, error.message, error.requestId);
+  }
+}
 ```
 
 ### WebSocket (Real-Time Data)

--- a/src/client.ts
+++ b/src/client.ts
@@ -206,11 +206,19 @@ export class PolymarketUS {
       clearTimeout(timeoutId);
 
       if (response.ok) {
-        const text = await response.text();
-        if (!text) {
-          return {} as T;
+        try {
+          const text = await response.text();
+          if (!text) {
+            return {} as T;
+          }
+          return JSON.parse(text) as T;
+        } catch (error) {
+          const message =
+            error instanceof Error
+              ? error.message
+              : 'Failed to parse response body';
+          throw new APIError(0, message, { requestId: correlationId });
         }
-        return JSON.parse(text) as T;
       }
 
       if (
@@ -234,7 +242,12 @@ export class PolymarketUS {
     response: Response,
     correlationId: string,
   ): Promise<never> {
-    const text = await response.text();
+    let text: string;
+    try {
+      text = await response.text();
+    } catch {
+      text = '';
+    }
     let message: string;
     let body: unknown;
     try {

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,10 +18,33 @@ import {
   Series,
   Sports,
 } from './resources';
+import {
+  backoffDelayMs,
+  canRetryMethod,
+  DEFAULT_MAX_RETRIES,
+  isRetryableStatus,
+  parseRetryAfterMs,
+  sleep,
+} from './retry';
 import { MarketsWebSocket, PrivateWebSocket } from './websocket';
 
 const GATEWAY_BASE_URL = 'https://gateway.polymarket.us';
 const API_BASE_URL = 'https://api.polymarket.us';
+
+// SDK identifier sent on every request.
+const USER_AGENT = 'polymarket-us-typescript';
+
+// Correlation id sent with every request so failures can be traced server-side.
+const CORRELATION_ID_HEADER = 'poly-correlation-id';
+
+function generateCorrelationId(): string {
+  const cryptoObj = (globalThis as { crypto?: { randomUUID?: () => string } })
+    .crypto;
+  if (cryptoObj?.randomUUID) {
+    return cryptoObj.randomUUID();
+  }
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`;
+}
 
 function getFetch(): typeof fetch {
   if (typeof fetch !== 'undefined') {
@@ -39,6 +62,12 @@ export interface PolymarketUSOptions {
   gatewayBaseUrl?: string;
   apiBaseUrl?: string;
   timeout?: number;
+  /**
+   * Maximum automatic retries for idempotent requests on transient failures
+   * (timeouts, connection errors, and 408/409/429/5xx). Non-idempotent requests
+   * (e.g. order placement) are never retried. Defaults to 2.
+   */
+  maxRetries?: number;
 }
 
 interface RequestOptions {
@@ -53,6 +82,7 @@ export class PolymarketUS {
   readonly gatewayBaseUrl: string;
   readonly apiBaseUrl: string;
   readonly timeout: number;
+  readonly maxRetries: number;
 
   readonly events: Events;
   readonly markets: Markets;
@@ -70,6 +100,7 @@ export class PolymarketUS {
     this.gatewayBaseUrl = options.gatewayBaseUrl || GATEWAY_BASE_URL;
     this.apiBaseUrl = options.apiBaseUrl || API_BASE_URL;
     this.timeout = options.timeout || 30000;
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
 
     this.events = new Events(this);
     this.markets = new Markets(this);
@@ -117,89 +148,125 @@ export class PolymarketUS {
       }
     }
 
-    const headers: Record<string, string> = {
-      'Content-Type': 'application/json',
-    };
-
-    if (authenticated) {
-      if (!this.keyId || !this.secretKey) {
-        throw new AuthenticationError(
-          'API key credentials required for authenticated endpoints. ' +
-            'Provide keyId and secretKey when initializing the client.',
-        );
-      }
-      const authHeaders = await createAuthHeaders(
-        this.keyId,
-        this.secretKey,
-        method,
-        url.pathname,
+    if (authenticated && (!this.keyId || !this.secretKey)) {
+      throw new AuthenticationError(
+        'API key credentials required for authenticated endpoints. ' +
+          'Provide keyId and secretKey when initializing the client.',
       );
-      Object.assign(headers, authHeaders);
     }
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+    const correlationId = generateCorrelationId();
 
-    try {
-      const response = await getFetch()(url.toString(), {
-        method,
-        headers,
-        body: body ? JSON.stringify(body) : undefined,
-        signal: controller.signal,
-      });
+    let attempt = 0;
+    for (;;) {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'User-Agent': USER_AGENT,
+        [CORRELATION_ID_HEADER]: correlationId,
+      };
 
-      clearTimeout(timeoutId);
-
-      if (!response.ok) {
-        await this.handleErrorResponse(response);
+      if (authenticated) {
+        const authHeaders = await createAuthHeaders(
+          this.keyId as string,
+          this.secretKey as string,
+          method,
+          url.pathname,
+        );
+        Object.assign(headers, authHeaders);
       }
 
-      const text = await response.text();
-      if (!text) {
-        return {} as T;
-      }
-      return JSON.parse(text) as T;
-    } catch (error) {
-      clearTimeout(timeoutId);
-      if (error instanceof APIError) {
-        throw error;
-      }
-      if (error instanceof Error) {
-        if (error.name === 'AbortError') {
-          throw new APIError(408, 'Request timeout');
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+      let response: Response;
+      try {
+        response = await getFetch()(url.toString(), {
+          method,
+          headers,
+          body: body ? JSON.stringify(body) : undefined,
+          signal: controller.signal,
+        });
+      } catch (error) {
+        clearTimeout(timeoutId);
+        if (canRetryMethod(method) && attempt < this.maxRetries) {
+          await sleep(backoffDelayMs(attempt));
+          attempt++;
+          continue;
         }
-        throw new APIError(0, error.message);
+        if (error instanceof Error && error.name === 'AbortError') {
+          throw new APIError(408, 'Request timeout', {
+            requestId: correlationId,
+          });
+        }
+        const message =
+          error instanceof Error ? error.message : 'Network error';
+        throw new APIError(0, message, { requestId: correlationId });
       }
-      throw error;
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        const text = await response.text();
+        if (!text) {
+          return {} as T;
+        }
+        return JSON.parse(text) as T;
+      }
+
+      if (
+        isRetryableStatus(response.status) &&
+        canRetryMethod(method) &&
+        attempt < this.maxRetries
+      ) {
+        const retryAfter = parseRetryAfterMs(
+          response.headers.get('Retry-After'),
+        );
+        await sleep(backoffDelayMs(attempt, retryAfter));
+        attempt++;
+        continue;
+      }
+
+      await this.handleErrorResponse(response, correlationId);
     }
   }
 
-  private async handleErrorResponse(response: Response): Promise<never> {
+  private async handleErrorResponse(
+    response: Response,
+    correlationId: string,
+  ): Promise<never> {
     const text = await response.text();
     let message: string;
+    let body: unknown;
     try {
       const data = JSON.parse(text);
+      body = data;
       message = data.message || data.error || response.statusText;
     } catch {
       message = text || response.statusText;
     }
 
+    const requestId =
+      response.headers.get(CORRELATION_ID_HEADER) ??
+      response.headers.get('x-request-id') ??
+      correlationId;
+    const errorOptions = { requestId, body };
+
     switch (response.status) {
       case 400:
-        throw new BadRequestError(message);
+        throw new BadRequestError(message, errorOptions);
       case 401:
-        throw new AuthenticationError(message);
+        throw new AuthenticationError(message, errorOptions);
       case 404:
-        throw new NotFoundError(message);
+        throw new NotFoundError(message, errorOptions);
       case 429:
-        throw new RateLimitError(message);
+        throw new RateLimitError(message, errorOptions);
       case 500:
       case 502:
       case 503:
       case 504:
-        throw new InternalServerError(message);
+        throw new InternalServerError(message, errorOptions);
       default:
-        throw new APIError(response.status, message);
+        throw new APIError(response.status, message, errorOptions);
     }
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -226,6 +226,9 @@ export class PolymarketUS {
         canRetryMethod(method) &&
         attempt < this.maxRetries
       ) {
+        // Release the connection back to the pool before retrying; an
+        // unconsumed body keeps the underlying socket open under undici.
+        await response.body?.cancel().catch(() => undefined);
         const retryAfter = parseRetryAfterMs(
           response.headers.get('Retry-After'),
         );

--- a/src/error.ts
+++ b/src/error.ts
@@ -5,49 +5,69 @@ export class PolymarketUSError extends Error {
   }
 }
 
+export interface APIErrorOptions {
+  code?: string;
+  /** Correlation id for tracing the request server-side. */
+  requestId?: string;
+  /** Parsed response body, when available. */
+  body?: unknown;
+}
+
 export class APIError extends PolymarketUSError {
   readonly status: number;
   readonly code?: string;
+  readonly requestId?: string;
+  readonly body?: unknown;
 
-  constructor(status: number, message: string, code?: string) {
+  constructor(status: number, message: string, options: APIErrorOptions = {}) {
     super(message);
     this.name = 'APIError';
     this.status = status;
-    this.code = code;
+    this.code = options.code;
+    this.requestId = options.requestId;
+    this.body = options.body;
   }
 }
 
+type SubclassOptions = Omit<APIErrorOptions, 'code'>;
+
 export class AuthenticationError extends APIError {
-  constructor(message: string = 'Authentication failed') {
-    super(401, message, 'authentication_error');
+  constructor(
+    message = 'Authentication failed',
+    options: SubclassOptions = {},
+  ) {
+    super(401, message, { ...options, code: 'authentication_error' });
     this.name = 'AuthenticationError';
   }
 }
 
 export class BadRequestError extends APIError {
-  constructor(message: string = 'Bad request') {
-    super(400, message, 'bad_request');
+  constructor(message = 'Bad request', options: SubclassOptions = {}) {
+    super(400, message, { ...options, code: 'bad_request' });
     this.name = 'BadRequestError';
   }
 }
 
 export class NotFoundError extends APIError {
-  constructor(message: string = 'Resource not found') {
-    super(404, message, 'not_found');
+  constructor(message = 'Resource not found', options: SubclassOptions = {}) {
+    super(404, message, { ...options, code: 'not_found' });
     this.name = 'NotFoundError';
   }
 }
 
 export class RateLimitError extends APIError {
-  constructor(message: string = 'Rate limit exceeded') {
-    super(429, message, 'rate_limit_exceeded');
+  constructor(message = 'Rate limit exceeded', options: SubclassOptions = {}) {
+    super(429, message, { ...options, code: 'rate_limit_exceeded' });
     this.name = 'RateLimitError';
   }
 }
 
 export class InternalServerError extends APIError {
-  constructor(message: string = 'Internal server error') {
-    super(500, message, 'internal_server_error');
+  constructor(
+    message = 'Internal server error',
+    options: SubclassOptions = {},
+  ) {
+    super(500, message, { ...options, code: 'internal_server_error' });
     this.name = 'InternalServerError';
   }
 }

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -1,0 +1,45 @@
+/**
+ * Retry helpers for the HTTP client.
+ *
+ * The Polymarket US API does not return `Retry-After` or `X-RateLimit-*`
+ * headers, so backoff is computed client-side with exponential growth and
+ * jitter. Only idempotent methods are retried automatically: order placement
+ * and other `POST` requests are never retried because the API has no idempotency
+ * key, so a retry after a partial failure could submit a duplicate order.
+ */
+
+export const DEFAULT_MAX_RETRIES = 2;
+
+const RETRYABLE_STATUS = new Set([408, 409, 429, 500, 502, 503, 504]);
+const IDEMPOTENT_METHODS = new Set(['GET', 'HEAD', 'OPTIONS', 'DELETE']);
+
+const BACKOFF_INITIAL_MS = 500;
+const BACKOFF_MAX_MS = 8000;
+
+export function isRetryableStatus(status: number): boolean {
+  return RETRYABLE_STATUS.has(status);
+}
+
+export function canRetryMethod(method: string): boolean {
+  return IDEMPOTENT_METHODS.has(method.toUpperCase());
+}
+
+export function backoffDelayMs(attempt: number, retryAfterMs?: number): number {
+  if (retryAfterMs !== undefined && retryAfterMs >= 0) {
+    return retryAfterMs;
+  }
+  const capped = Math.min(BACKOFF_INITIAL_MS * 2 ** attempt, BACKOFF_MAX_MS);
+  return capped / 2 + Math.random() * (capped / 2);
+}
+
+export function parseRetryAfterMs(header: string | null): number | undefined {
+  if (!header) {
+    return undefined;
+  }
+  const seconds = Number(header);
+  return Number.isFinite(seconds) ? seconds * 1000 : undefined;
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/retry.ts
+++ b/src/retry.ts
@@ -26,7 +26,8 @@ export function canRetryMethod(method: string): boolean {
 
 export function backoffDelayMs(attempt: number, retryAfterMs?: number): number {
   if (retryAfterMs !== undefined && retryAfterMs >= 0) {
-    return retryAfterMs;
+    // Clamp so a hostile or malformed Retry-After cannot block indefinitely.
+    return Math.min(retryAfterMs, BACKOFF_MAX_MS);
   }
   const capped = Math.min(BACKOFF_INITIAL_MS * 2 ** attempt, BACKOFF_MAX_MS);
   return capped / 2 + Math.random() * (capped / 2);

--- a/tests/error.test.ts
+++ b/tests/error.test.ts
@@ -17,13 +17,19 @@ describe('Error Classes', () => {
     expect(error.name).toBe('PolymarketUSError');
   });
 
-  test('APIError should have status and code', () => {
-    const error = new APIError(400, 'bad request', 'invalid_param');
+  test('APIError should have status, code, requestId, and body', () => {
+    const error = new APIError(400, 'bad request', {
+      code: 'invalid_param',
+      requestId: 'req-123',
+      body: { detail: 'nope' },
+    });
     expect(error).toBeInstanceOf(PolymarketUSError);
     expect(error).toBeInstanceOf(APIError);
     expect(error.status).toBe(400);
     expect(error.code).toBe('invalid_param');
     expect(error.message).toBe('bad request');
+    expect(error.requestId).toBe('req-123');
+    expect(error.body).toEqual({ detail: 'nope' });
   });
 
   test('AuthenticationError should have status 401', () => {

--- a/tests/http-errors.test.ts
+++ b/tests/http-errors.test.ts
@@ -16,7 +16,7 @@ describe('HTTP Error Handling', () => {
 
   beforeEach(() => {
     mockFetch.mockReset();
-    client = new PolymarketUS();
+    client = new PolymarketUS({ maxRetries: 0 });
   });
 
   describe('JSON error responses', () => {
@@ -153,7 +153,7 @@ describe('HTTP Error Handling', () => {
 
   describe('Timeout handling', () => {
     test('should throw APIError on timeout', async () => {
-      const client = new PolymarketUS({ timeout: 50 });
+      const client = new PolymarketUS({ timeout: 50, maxRetries: 0 });
 
       mockFetch.mockImplementationOnce(
         () =>
@@ -176,7 +176,7 @@ describe('HTTP Error Handling', () => {
     });
 
     test('should succeed within timeout', async () => {
-      const client = new PolymarketUS({ timeout: 200 });
+      const client = new PolymarketUS({ timeout: 200, maxRetries: 0 });
 
       mockFetch.mockImplementationOnce(
         () =>

--- a/tests/retries.test.ts
+++ b/tests/retries.test.ts
@@ -1,9 +1,10 @@
 import {
-  type APIError,
+  APIError,
   BadRequestError,
   InternalServerError,
   PolymarketUS,
 } from '../src';
+import { backoffDelayMs } from '../src/retry';
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch as jest.Mock;
@@ -102,5 +103,23 @@ describe('Retries', () => {
     >;
     expect(headers['User-Agent']).toBe('polymarket-us-typescript');
     expect(headers['poly-correlation-id']).toBeTruthy();
+  });
+
+  test('wraps a malformed success body in APIError', async () => {
+    mockFetch.mockResolvedValueOnce(new Response('not json{', { status: 200 }));
+    const client = new PolymarketUS({ maxRetries: 0 });
+
+    try {
+      await client.events.list();
+      fail('Expected error to be thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(APIError);
+      expect((error as APIError).status).toBe(0);
+    }
+  });
+
+  test('clamps Retry-After to the backoff ceiling', () => {
+    expect(backoffDelayMs(0, 3_600_000)).toBe(8000);
+    expect(backoffDelayMs(0, Number.POSITIVE_INFINITY)).toBe(8000);
   });
 });

--- a/tests/retries.test.ts
+++ b/tests/retries.test.ts
@@ -1,0 +1,106 @@
+import {
+  type APIError,
+  BadRequestError,
+  InternalServerError,
+  PolymarketUS,
+} from '../src';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as jest.Mock;
+
+const TEST_SECRET_KEY = 'nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=';
+
+function jsonResponse(
+  status: number,
+  payload: unknown = { message: 'error' },
+): Response {
+  return new Response(JSON.stringify(payload), { status });
+}
+
+describe('Retries', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  test('retries GET on 500 then succeeds', async () => {
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse(500))
+      .mockResolvedValueOnce(jsonResponse(200, { events: [] }));
+    const client = new PolymarketUS();
+
+    const result = await client.events.list();
+
+    expect(result).toEqual({ events: [] });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('exhausts retries and throws', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(503));
+    const client = new PolymarketUS({ maxRetries: 2 });
+
+    await expect(client.events.list()).rejects.toThrow(InternalServerError);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  test('retries GET on network error then succeeds', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('network down'))
+      .mockResolvedValueOnce(jsonResponse(200, { events: [] }));
+    const client = new PolymarketUS();
+
+    const result = await client.events.list();
+
+    expect(result).toEqual({ events: [] });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('does not retry POST requests', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(500));
+    const client = new PolymarketUS({
+      keyId: 'test-key',
+      secretKey: TEST_SECRET_KEY,
+    });
+
+    await expect(
+      client.orders.create({
+        marketSlug: 'm',
+        intent: 'ORDER_INTENT_BUY_LONG',
+      }),
+    ).rejects.toThrow(InternalServerError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not retry 4xx responses', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(400));
+    const client = new PolymarketUS();
+
+    await expect(client.events.list()).rejects.toThrow(BadRequestError);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('errors carry a request id', async () => {
+    mockFetch.mockResolvedValue(jsonResponse(400));
+    const client = new PolymarketUS({ maxRetries: 0 });
+
+    try {
+      await client.events.list();
+      fail('Expected error to be thrown');
+    } catch (error) {
+      expect((error as APIError).requestId).toBeTruthy();
+    }
+  });
+
+  test('sends user-agent and correlation-id headers', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, { events: [] }));
+    const client = new PolymarketUS();
+
+    await client.events.list();
+
+    const headers = mockFetch.mock.calls[0][1].headers as Record<
+      string,
+      string
+    >;
+    expect(headers['User-Agent']).toBe('polymarket-us-typescript');
+    expect(headers['poly-correlation-id']).toBeTruthy();
+  });
+});

--- a/tests/retries.test.ts
+++ b/tests/retries.test.ts
@@ -35,6 +35,22 @@ describe('Retries', () => {
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
+  test('cancels the response body before retrying', async () => {
+    const errorResponse = new Response('err', { status: 500 });
+    const cancelSpy = jest.spyOn(
+      errorResponse.body as ReadableStream,
+      'cancel',
+    );
+    mockFetch
+      .mockResolvedValueOnce(errorResponse)
+      .mockResolvedValueOnce(jsonResponse(200, { events: [] }));
+    const client = new PolymarketUS();
+
+    await client.events.list();
+
+    expect(cancelSpy).toHaveBeenCalled();
+  });
+
   test('exhausts retries and throws', async () => {
     mockFetch.mockResolvedValue(jsonResponse(503));
     const client = new PolymarketUS({ maxRetries: 2 });


### PR DESCRIPTION
## summary
hardens the http client for production use:

- automatic retries with exponential backoff + jitter for idempotent requests (`GET`/`DELETE`) on network errors, timeouts, and `408`/`409`/`429`/`5xx`. configurable via `maxRetries` (default 2).
- non-idempotent requests (order placement, etc.) are never auto-retried, since the api has no idempotency key and a retry could submit a duplicate order.
- every request now sends a `User-Agent` and a generated `poly-correlation-id` for server-side tracing.
- `APIError` now carries `requestId` and `body` (via an options bag) alongside the existing `status`/`code`.

no `Retry-After`/`X-RateLimit-*` headers are emitted by the api today, so backoff is purely client-side (the parser honors `Retry-After` defensively if it ever appears).

## test plan
- [x] `pnpm lint` (biome)
- [x] `pnpm typecheck` / `pnpm build`
- [x] `pnpm test` (138 passed; new `tests/retries.test.ts` covers retry-then-succeed, exhausted retries, network-error retry, post-not-retried, 4xx-not-retried, request-id, and header propagation)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shared HTTP request path used by all API calls, including trading, but explicitly skips POST retries to limit duplicate-order risk; retry semantics should be reviewed for 409 handling on GET.
> 
> **Overview**
> Hardens the HTTP client for production: **automatic retries** (default `maxRetries: 2`) with exponential backoff and jitter for **idempotent** calls (`GET`, `DELETE`, etc.) on network failures, timeouts, and `408`/`409`/`429`/`5xx`. **`POST` / order placement is never auto-retried** to avoid duplicate submissions without an idempotency key.
> 
> Every outbound request now includes a fixed **`User-Agent`** and a stable per-attempt **`poly-correlation-id`** for tracing. **`APIError`** and typed subclasses accept an options bag with **`requestId`** (from correlation / response headers) and parsed error **`body`**; timeouts and network failures also surface `requestId`.
> 
> The request path was refactored into a retry loop that **cancels unconsumed response bodies** before retrying (connection pooling), honors **`Retry-After`** when present (clamped), and documents behavior in the README. New **`tests/retries.test.ts`**; existing HTTP/error tests disable retries where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 082119b0f1d69028d2b2be2a0e98d3079013fd3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->