### PR TITLE
feat: add websocket auto-reconnect, resubscribe, and re-auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,14 @@ const client = new PolymarketUS({
 
 ### WebSocket (Real-Time Data)
 
+> **Reconnection**: connections automatically reconnect with exponential backoff
+> on unexpected drops, re-sign the auth handshake, and replay every active
+> subscription. A `reconnect` event fires after a successful reconnect. Reconnect
+> stops on fatal auth failures (401/403/429). Disable with `autoReconnect: false`.
+> Note that `order`, `position`, and `trade` streams do not replay history on
+> reconnect; resubscribe to `SUBSCRIPTION_TYPE_ORDER_SNAPSHOT` if you need current
+> open orders, while market data and account balance snapshots are sent automatically.
+
 ```typescript
 import { PolymarketUS } from 'polymarket-us';
 
@@ -267,6 +275,7 @@ marketsWs.close();
 - `accountBalanceSnapshot` - Initial balance
 - `accountBalanceUpdate` - Balance changes
 - `heartbeat` - Connection keepalive
+- `reconnect` - Reconnected and resubscribed after a drop
 - `error` - Error events
 - `close` - Connection closed
 
@@ -275,6 +284,7 @@ marketsWs.close();
 - `marketDataLite` - Lightweight price data
 - `trade` - Trade notifications
 - `heartbeat` - Connection keepalive
+- `reconnect` - Reconnected and resubscribed after a drop
 - `error` - Error events
 - `close` - Connection closed
 

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -11,7 +11,19 @@ export interface WebSocketOptions {
   keyId: string;
   secretKey: string;
   baseUrl?: string;
+  /** Reconnect and replay subscriptions on unexpected drops (default true). */
+  autoReconnect?: boolean;
+  /** Max reconnect attempts per drop (default unlimited). */
+  reconnectMaxAttempts?: number;
 }
+
+/** Events emitted by every WebSocket, used as the base constraint. */
+export type BaseWebSocketEvents = {
+  open: () => void;
+  close: () => void;
+  reconnect: () => void;
+  error: (error: PolymarketUSError) => void;
+};
 
 type WebSocketLike = {
   send(data: string): void;
@@ -24,6 +36,35 @@ type WebSocketLike = {
 };
 
 const WS_OPEN = 1;
+
+// WebSocket upgrade failures with these statuses are fatal (bad credentials or
+// rate limiting) and must not trigger reconnect attempts.
+const FATAL_AUTH_STATUSES = new Set([401, 403, 429]);
+
+const RECONNECT_INITIAL_MS = 500;
+const RECONNECT_MAX_MS = 30000;
+
+function reconnectDelayMs(attempt: number): number {
+  const capped = Math.min(
+    RECONNECT_INITIAL_MS * 2 ** attempt,
+    RECONNECT_MAX_MS,
+  );
+  return capped / 2 + Math.random() * (capped / 2);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Extract the HTTP status from a failed WebSocket upgrade error, if present.
+ * The `ws` library surfaces this as `Unexpected server response: <status>`.
+ */
+function upgradeStatus(error: unknown): number | undefined {
+  const message = error instanceof Error ? error.message : String(error);
+  const match = message.match(/\b(\d{3})\b/);
+  return match ? Number(match[1]) : undefined;
+}
 
 function isBrowser(): boolean {
   return (
@@ -54,24 +95,51 @@ async function getWebSocketImpl(): Promise<
   ) => WebSocketLike;
 }
 
+type TrackedSubscription = {
+  subscriptionType: PrivateSubscriptionType | MarketSubscriptionType;
+  marketSlugs?: string[];
+};
+
 export abstract class BaseWebSocket<
-  // biome-ignore lint/suspicious/noExplicitAny: complex generics needed for type-safe event emitter
-  EventTypes extends Record<string, (...args: any[]) => any>,
+  EventTypes extends BaseWebSocketEvents,
 > extends EventEmitter<EventTypes> {
   protected socket: WebSocketLike | null = null;
   protected readonly options: WebSocketOptions;
   protected readonly path: string;
 
+  private readonly autoReconnect: boolean;
+  private readonly reconnectMaxAttempts?: number;
+  private readonly subscriptions = new Map<string, TrackedSubscription>();
+  private closed = false;
+
   constructor(options: WebSocketOptions, path: string) {
     super();
     this.options = options;
     this.path = path;
+    this.autoReconnect = options.autoReconnect ?? true;
+    this.reconnectMaxAttempts = options.reconnectMaxAttempts;
+  }
+
+  // Bridges the generic emitter to the always-present base events. `EventTypes`
+  // is constrained to `BaseWebSocketEvents`, so these events always exist with
+  // compatible signatures; the cast satisfies the generic `_emit` signature.
+  private get emitter(): { _emit(event: string, ...args: unknown[]): void } {
+    return this as unknown as {
+      _emit(event: string, ...args: unknown[]): void;
+    };
   }
 
   async connect(): Promise<void> {
+    this.closed = false;
+    await this.openSocket();
+    this.emitter._emit('open');
+  }
+
+  private async openSocket(): Promise<void> {
     const baseUrl = this.options.baseUrl || 'wss://api.polymarket.us';
     const url = `${baseUrl}${this.path}`;
 
+    // Re-sign on every (re)connect: the timestamp must be within the skew window.
     const authHeaders = await createAuthHeaders(
       this.options.keyId,
       this.options.secretKey,
@@ -80,34 +148,96 @@ export abstract class BaseWebSocket<
     );
 
     const WebSocketImpl = await getWebSocketImpl();
+    const socket = new WebSocketImpl(url, [], { headers: authHeaders });
+    this.socket = socket;
 
-    this.socket = new WebSocketImpl(url, [], {
-      headers: authHeaders,
-    });
-
-    this.socket.addEventListener('message', (event: { data: string }) => {
+    socket.addEventListener('message', (event: { data: string }) => {
       this.handleMessage(event.data.toString());
     });
-
-    this.socket.addEventListener('error', (event: unknown) => {
-      this.handleError(event);
+    socket.addEventListener('error', (event: unknown) => {
+      this.emitter._emit('error', this.toError(event));
+    });
+    socket.addEventListener('close', () => {
+      this.onClose();
     });
 
-    this.socket.addEventListener('close', () => {
-      this.handleClose();
-    });
-
-    const socket = this.socket;
-    return new Promise((resolve, reject) => {
-      socket.addEventListener('open', () => {
-        // biome-ignore lint/suspicious/noExplicitAny: emit open event to subclass
-        (this as any)._emit('open');
-        resolve();
-      });
-      socket.addEventListener('error', (e: unknown) =>
-        reject(new PolymarketUSError(`WebSocket connection failed: ${e}`)),
+    return new Promise<void>((resolve, reject) => {
+      socket.addEventListener('open', () => resolve());
+      socket.addEventListener('error', (event: unknown) =>
+        reject(this.toError(event)),
       );
     });
+  }
+
+  private onClose(): void {
+    if (this.closed) {
+      this.emitter._emit('close');
+      return;
+    }
+    if (!this.autoReconnect) {
+      this.emitter._emit('close');
+      return;
+    }
+    void this.reconnect();
+  }
+
+  private async reconnect(): Promise<void> {
+    let attempt = 0;
+    while (
+      !this.closed &&
+      (this.reconnectMaxAttempts === undefined ||
+        attempt < this.reconnectMaxAttempts)
+    ) {
+      await sleep(reconnectDelayMs(attempt));
+      if (this.closed) {
+        return;
+      }
+      try {
+        await this.openSocket();
+      } catch (error) {
+        const status = upgradeStatus(error);
+        if (status !== undefined && FATAL_AUTH_STATUSES.has(status)) {
+          this.emitter._emit(
+            'error',
+            new PolymarketUSError(`WebSocket auth failed (${status})`),
+          );
+          this.emitter._emit('close');
+          return;
+        }
+        attempt++;
+        continue;
+      }
+      this.emitter._emit('reconnect');
+      this.resubscribe();
+      return;
+    }
+    this.emitter._emit('close');
+  }
+
+  private resubscribe(): void {
+    for (const [requestId, sub] of this.subscriptions) {
+      this.send({
+        subscribe: {
+          requestId,
+          subscriptionType: sub.subscriptionType,
+          marketSlugs: sub.marketSlugs,
+        },
+      });
+    }
+  }
+
+  private toError(event: unknown): PolymarketUSError {
+    if (event instanceof Error) {
+      return new PolymarketUSError(event.message);
+    }
+    const candidate = event as { error?: unknown; message?: string };
+    if (candidate?.error instanceof Error) {
+      return new PolymarketUSError(candidate.error.message);
+    }
+    if (typeof candidate?.message === 'string') {
+      return new PolymarketUSError(candidate.message);
+    }
+    return new PolymarketUSError('WebSocket error occurred');
   }
 
   send(request: WebSocketRequest): void {
@@ -129,15 +259,18 @@ export abstract class BaseWebSocket<
         marketSlugs,
       },
     });
+    this.subscriptions.set(requestId, { subscriptionType, marketSlugs });
   }
 
   unsubscribe(requestId: string): void {
+    this.subscriptions.delete(requestId);
     this.send({
       unsubscribe: { requestId },
     });
   }
 
   close(): void {
+    this.closed = true;
     if (this.socket) {
       this.socket.close(1000, 'OK');
       this.socket = null;
@@ -149,6 +282,4 @@ export abstract class BaseWebSocket<
   }
 
   protected abstract handleMessage(data: string): void;
-  protected abstract handleError(event: unknown): void;
-  protected abstract handleClose(): void;
 }

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -139,6 +139,9 @@ export abstract class BaseWebSocket<
 
   async connect(): Promise<void> {
     this.closed = false;
+    // Reset before opening so a failed (re)connect doesn't leave a stale
+    // `established` flag that would trigger a background reconnect loop.
+    this.established = false;
     await this.openSocket();
     this.established = true;
     this.emitter._emit('open');
@@ -210,6 +213,8 @@ export abstract class BaseWebSocket<
       ) {
         await sleep(reconnectDelayMs(attempt));
         if (this.closed) {
+          // Closed during backoff: surface the close like any other teardown.
+          this.emitter._emit('close');
           return;
         }
         try {
@@ -232,6 +237,7 @@ export abstract class BaseWebSocket<
         if (this.closed) {
           this.socket?.close(1000, 'OK');
           this.socket = null;
+          this.emitter._emit('close');
           return;
         }
         this.resubscribe();

--- a/src/websocket/base.ts
+++ b/src/websocket/base.ts
@@ -62,7 +62,9 @@ function sleep(ms: number): Promise<void> {
  */
 function upgradeStatus(error: unknown): number | undefined {
   const message = error instanceof Error ? error.message : String(error);
-  const match = message.match(/\b(\d{3})\b/);
+  // Match only the `ws` upgrade-failure format so an incidental 3-digit number
+  // (a port, a timeout, etc.) is not misread as a fatal auth status.
+  const match = message.match(/unexpected server response:\s*(\d{3})/i);
   return match ? Number(match[1]) : undefined;
 }
 
@@ -111,6 +113,12 @@ export abstract class BaseWebSocket<
   private readonly reconnectMaxAttempts?: number;
   private readonly subscriptions = new Map<string, TrackedSubscription>();
   private closed = false;
+  // True only after a connection has successfully opened, so an initial connect
+  // failure does not trigger background reconnects.
+  private established = false;
+  // True while a reconnect loop is running, so a failed attempt's own `close`
+  // event does not spawn a second, parallel loop.
+  private reconnecting = false;
 
   constructor(options: WebSocketOptions, path: string) {
     super();
@@ -132,6 +140,7 @@ export abstract class BaseWebSocket<
   async connect(): Promise<void> {
     this.closed = false;
     await this.openSocket();
+    this.established = true;
     this.emitter._emit('open');
   }
 
@@ -170,8 +179,17 @@ export abstract class BaseWebSocket<
   }
 
   private onClose(): void {
+    // A failed reconnect attempt's socket also fires `close`; ignore it so we
+    // don't spawn a second, parallel reconnect loop.
+    if (this.reconnecting) {
+      return;
+    }
     if (this.closed) {
       this.emitter._emit('close');
+      return;
+    }
+    // An initial connect failure is surfaced via the rejected connect() promise.
+    if (!this.established) {
       return;
     }
     if (!this.autoReconnect) {
@@ -182,36 +200,51 @@ export abstract class BaseWebSocket<
   }
 
   private async reconnect(): Promise<void> {
-    let attempt = 0;
-    while (
-      !this.closed &&
-      (this.reconnectMaxAttempts === undefined ||
-        attempt < this.reconnectMaxAttempts)
-    ) {
-      await sleep(reconnectDelayMs(attempt));
-      if (this.closed) {
-        return;
-      }
-      try {
-        await this.openSocket();
-      } catch (error) {
-        const status = upgradeStatus(error);
-        if (status !== undefined && FATAL_AUTH_STATUSES.has(status)) {
-          this.emitter._emit(
-            'error',
-            new PolymarketUSError(`WebSocket auth failed (${status})`),
-          );
-          this.emitter._emit('close');
+    this.reconnecting = true;
+    try {
+      let attempt = 0;
+      while (
+        !this.closed &&
+        (this.reconnectMaxAttempts === undefined ||
+          attempt < this.reconnectMaxAttempts)
+      ) {
+        await sleep(reconnectDelayMs(attempt));
+        if (this.closed) {
           return;
         }
-        attempt++;
-        continue;
+        try {
+          await this.openSocket();
+        } catch (error) {
+          const status = upgradeStatus(error);
+          if (status !== undefined && FATAL_AUTH_STATUSES.has(status)) {
+            this.established = false;
+            this.emitter._emit(
+              'error',
+              new PolymarketUSError(`WebSocket auth failed (${status})`),
+            );
+            this.emitter._emit('close');
+            return;
+          }
+          attempt++;
+          continue;
+        }
+        // The user may have called close() while the upgrade was in flight.
+        if (this.closed) {
+          this.socket?.close(1000, 'OK');
+          this.socket = null;
+          return;
+        }
+        this.resubscribe();
+        this.emitter._emit('reconnect');
+        return;
       }
-      this.emitter._emit('reconnect');
-      this.resubscribe();
-      return;
+      // Exhausted attempts: connection is no longer established, so a late
+      // `close` from a failed socket won't restart reconnection.
+      this.established = false;
+      this.emitter._emit('close');
+    } finally {
+      this.reconnecting = false;
     }
-    this.emitter._emit('close');
   }
 
   private resubscribe(): void {

--- a/src/websocket/markets.ts
+++ b/src/websocket/markets.ts
@@ -16,6 +16,7 @@ type MarketEventTypes = {
   trade: (data: Trade) => void;
   heartbeat: () => void;
   error: (error: PolymarketUSError | WebSocketError) => void;
+  reconnect: () => void;
   close: () => void;
 };
 
@@ -79,15 +80,5 @@ export class MarketsWebSocket extends BaseWebSocket<MarketEventTypes> {
     } else if ('trade' in message) {
       this._emit('trade', message as Trade);
     }
-  }
-
-  protected handleError(event: unknown): void {
-    const message =
-      event instanceof Error ? event.message : 'WebSocket error occurred';
-    this._emit('error', new PolymarketUSError(message));
-  }
-
-  protected handleClose(): void {
-    this._emit('close');
   }
 }

--- a/src/websocket/private.ts
+++ b/src/websocket/private.ts
@@ -22,6 +22,7 @@ type PrivateEventTypes = {
   accountBalanceUpdate: (data: AccountBalanceUpdate) => void;
   heartbeat: () => void;
   error: (error: PolymarketUSError | WebSocketError) => void;
+  reconnect: () => void;
   close: () => void;
 };
 
@@ -102,15 +103,5 @@ export class PrivateWebSocket extends BaseWebSocket<PrivateEventTypes> {
     ) {
       this._emit('accountBalanceUpdate', message as AccountBalanceUpdate);
     }
-  }
-
-  protected handleError(event: unknown): void {
-    const message =
-      event instanceof Error ? event.message : 'WebSocket error occurred';
-    this._emit('error', new PolymarketUSError(message));
-  }
-
-  protected handleClose(): void {
-    this._emit('close');
   }
 }

--- a/tests/websocket-reconnect.test.ts
+++ b/tests/websocket-reconnect.test.ts
@@ -171,12 +171,29 @@ describe('WebSocket reconnect & resubscribe', () => {
         };
       });
       const onReconnect = jest.fn();
+      const onClose = jest.fn();
       ws.on('reconnect', onReconnect);
+      ws.on('close', onClose);
 
       await (ws as Internal).reconnect();
 
       expect(onReconnect).not.toHaveBeenCalled();
       expect(socketClose).toHaveBeenCalled();
+      // Closing mid-handshake should still surface a close event.
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('connect resets established so a failed reconnect stays quiet', async () => {
+      const ws = new PrivateWebSocket(validOptions);
+      // Leftover from a previous successful session.
+      (ws as Internal).established = true;
+      (ws as Internal).openSocket = jest
+        .fn()
+        .mockRejectedValue(new Error('nope'));
+
+      await expect(ws.connect()).rejects.toBeDefined();
+
+      expect((ws as Internal).established).toBe(false);
     });
   });
 });

--- a/tests/websocket-reconnect.test.ts
+++ b/tests/websocket-reconnect.test.ts
@@ -101,4 +101,82 @@ describe('WebSocket reconnect & resubscribe', () => {
       expect(onClose).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('onClose guard', () => {
+    test('does not start a second loop while already reconnecting', () => {
+      const ws = new PrivateWebSocket(validOptions);
+      (ws as Internal).established = true;
+      (ws as Internal).reconnecting = true;
+      const spy = jest.fn();
+      (ws as Internal).reconnect = spy;
+
+      (ws as Internal).onClose();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('does not reconnect before the first successful connect', () => {
+      const ws = new PrivateWebSocket(validOptions);
+      (ws as Internal).established = false;
+      const spy = jest.fn();
+      (ws as Internal).reconnect = spy;
+
+      (ws as Internal).onClose();
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+
+    test('reconnects after an established connection drops', () => {
+      const ws = new PrivateWebSocket(validOptions);
+      (ws as Internal).established = true;
+      (ws as Internal).reconnecting = false;
+      const spy = jest.fn();
+      (ws as Internal).reconnect = spy;
+
+      (ws as Internal).onClose();
+
+      expect(spy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('reconnect edge cases', () => {
+    test('does not treat an incidental 3-digit number as fatal auth', async () => {
+      const ws = new PrivateWebSocket({
+        ...validOptions,
+        reconnectMaxAttempts: 1,
+      });
+      (ws as Internal).openSocket = jest
+        .fn()
+        .mockRejectedValue(new Error('timeout after 401 ms'));
+      const onError = jest.fn();
+      const onClose = jest.fn();
+      ws.on('error', onError);
+      ws.on('close', onClose);
+
+      await (ws as Internal).reconnect();
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not resurrect a connection closed mid-handshake', async () => {
+      const ws = new PrivateWebSocket(validOptions);
+      const socketClose = jest.fn();
+      (ws as Internal).openSocket = jest.fn().mockImplementation(async () => {
+        (ws as Internal).closed = true;
+        (ws as Internal).socket = {
+          readyState: 1,
+          send: jest.fn(),
+          close: socketClose,
+        };
+      });
+      const onReconnect = jest.fn();
+      ws.on('reconnect', onReconnect);
+
+      await (ws as Internal).reconnect();
+
+      expect(onReconnect).not.toHaveBeenCalled();
+      expect(socketClose).toHaveBeenCalled();
+    });
+  });
 });

--- a/tests/websocket-reconnect.test.ts
+++ b/tests/websocket-reconnect.test.ts
@@ -1,0 +1,104 @@
+import { MarketsWebSocket, PrivateWebSocket } from '../src';
+
+const validOptions = {
+  keyId: 'test-key',
+  secretKey: 'nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=',
+};
+
+// biome-ignore lint/suspicious/noExplicitAny: tests reach into protected/private members
+type Internal = any;
+
+function mockSocket() {
+  return { readyState: 1, send: jest.fn(), close: jest.fn() };
+}
+
+describe('WebSocket reconnect & resubscribe', () => {
+  describe('subscription tracking', () => {
+    test('subscribe records the subscription', () => {
+      const ws = new PrivateWebSocket(validOptions);
+      (ws as Internal).socket = mockSocket();
+
+      ws.subscribeOrders('ord-1', ['mkt-a']);
+
+      const tracked = (ws as Internal).subscriptions.get('ord-1');
+      expect(tracked.subscriptionType).toBe('SUBSCRIPTION_TYPE_ORDER');
+      expect(tracked.marketSlugs).toEqual(['mkt-a']);
+    });
+
+    test('unsubscribe clears the subscription', () => {
+      const ws = new MarketsWebSocket(validOptions);
+      (ws as Internal).socket = mockSocket();
+
+      ws.subscribeMarketData('md-1', ['mkt-a']);
+      expect((ws as Internal).subscriptions.has('md-1')).toBe(true);
+
+      ws.unsubscribe('md-1');
+      expect((ws as Internal).subscriptions.has('md-1')).toBe(false);
+    });
+
+    test('resubscribe replays all tracked subscriptions', () => {
+      const ws = new MarketsWebSocket(validOptions);
+      const socket = mockSocket();
+      (ws as Internal).socket = socket;
+
+      ws.subscribeMarketData('md-1', ['mkt-a']);
+      ws.subscribeTrades('tr-1', ['mkt-b']);
+      socket.send.mockClear();
+
+      (ws as Internal).resubscribe();
+
+      expect(socket.send).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('reconnect loop', () => {
+    test('reconnects after a transient failure', async () => {
+      const ws = new PrivateWebSocket(validOptions);
+      const openSocket = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce(undefined);
+      (ws as Internal).openSocket = openSocket;
+      const onReconnect = jest.fn();
+      ws.on('reconnect', onReconnect);
+
+      await (ws as Internal).reconnect();
+
+      expect(openSocket).toHaveBeenCalledTimes(2);
+      expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+
+    test('stops reconnecting on fatal auth failure', async () => {
+      const ws = new PrivateWebSocket(validOptions);
+      (ws as Internal).openSocket = jest
+        .fn()
+        .mockRejectedValue(new Error('Unexpected server response: 401'));
+      const onError = jest.fn();
+      const onClose = jest.fn();
+      ws.on('error', onError);
+      ws.on('close', onClose);
+
+      await (ws as Internal).reconnect();
+
+      expect((ws as Internal).openSocket).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    test('gives up after reconnectMaxAttempts', async () => {
+      const ws = new PrivateWebSocket({
+        ...validOptions,
+        reconnectMaxAttempts: 2,
+      });
+      const openSocket = jest.fn().mockRejectedValue(new Error('network'));
+      (ws as Internal).openSocket = openSocket;
+      const onClose = jest.fn();
+      ws.on('close', onClose);
+
+      await (ws as Internal).reconnect();
+
+      expect(openSocket).toHaveBeenCalledTimes(2);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## summary
makes the private and markets websockets resilient to dropped connections:

- automatic reconnect with exponential backoff + jitter on unexpected drops (`autoReconnect: true` by default; `reconnectMaxAttempts` configurable).
- each reconnect re-signs the auth handshake with a fresh timestamp/signature (the api authenticates only at upgrade), and replays every active subscription.
- subscriptions are tracked on `subscribe`/`unsubscribe`; a `reconnect` event fires after a successful reconnect.
- reconnect stops on fatal upgrade failures (401/403/429, parsed from the `ws` error); transient/network failures keep retrying.
- connection lifecycle (open/close/reconnect/error) is now owned by the base class.

note: per the server protocol, `order`/`position`/`trade` streams don't replay history on resubscribe (market-data and account-balance snapshots are re-sent automatically); use `SUBSCRIPTION_TYPE_ORDER_SNAPSHOT` to refetch open orders after a reconnect.

## test plan
- [x] `pnpm lint` (biome)
- [x] `pnpm typecheck` / `pnpm build`
- [x] `pnpm test` (137 passed; new `tests/websocket-reconnect.test.ts` covers subscription tracking, resubscribe replay, transient-then-success reconnect, fatal-auth stop, and max-attempts)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time connection lifecycle and auth on reconnect; incorrect behavior could miss updates or retry invalid credentials, though fatal auth stops and tests mitigate common cases.
> 
> **Overview**
> Adds **automatic WebSocket recovery** for private and markets streams: on unexpected drops, `BaseWebSocket` reconnects with **exponential backoff + jitter**, **re-signs** the upgrade with fresh auth headers, **replays** tracked `subscribe` calls, and emits a new **`reconnect`** event. Options **`autoReconnect`** (default on) and **`reconnectMaxAttempts`** control behavior; **401/403/429** upgrade failures stop retries and surface `error`/`close`.
> 
> Connection **open/close/error** handling moves into the base class (subclasses drop duplicate `handleError`/`handleClose`). **`subscribe`/`unsubscribe`** maintain a subscription map for replay. README documents reconnect semantics and notes that **order/position/trade** history is not replayed on resubscribe (use order snapshot where needed).
> 
> New **`tests/websocket-reconnect.test.ts`** covers tracking, resubscribe, reconnect loop, guards, and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b760be9d78ac5791c33b6c6ab18ad4cb686563ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->