### PR TITLE
feat: add auto-pagination iterators for list endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ const activities = await client.portfolio.activities();
 const balances = await client.account.balances();
 ```
 
+## Pagination
+
+List endpoints expose `iterate()` async generators that transparently page
+through all results. Offset-paginated resources (`events`, `markets`, `series`)
+and the cursor-paginated activity feed are both supported:
+
+```typescript
+// Offset-paginated resources
+for await (const market of client.markets.iterate({ active: true })) {
+  console.log(market.slug);
+}
+
+// Cursor-paginated activity history (authenticated)
+for await (const activity of client.portfolio.iterateActivities()) {
+  console.log(activity.type);
+}
+```
+
 ## Authentication
 
 Polymarket US uses Ed25519 signature authentication. Generate API keys at [polymarket.us/developer](https://polymarket.us/developer).

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -19,17 +19,19 @@ export async function* paginateOffset<T>(
   itemsKey: string,
   pageSize: number = DEFAULT_PAGE_SIZE,
 ): AsyncGenerator<T> {
+  // Clamp so a non-positive page size cannot spin forever (offset never advances).
+  const size = Math.max(1, pageSize);
   let offset = 0;
   for (;;) {
-    const page = await fetchPage(offset, pageSize);
+    const page = await fetchPage(offset, size);
     const items = (page[itemsKey] as T[] | undefined) ?? [];
     for (const item of items) {
       yield item;
     }
-    if (items.length < pageSize) {
+    if (items.length < size) {
       return;
     }
-    offset += pageSize;
+    offset += size;
   }
 }
 

--- a/src/pagination.ts
+++ b/src/pagination.ts
@@ -1,0 +1,55 @@
+/**
+ * Auto-pagination helpers for list endpoints.
+ *
+ * The API uses two pagination styles:
+ *
+ * - cursor-based (`nextCursor` / `eof`) for activities and positions, and
+ * - offset-based (bare array responses) for events, markets, series, and tags.
+ *
+ * These helpers transparently walk all pages and yield individual items.
+ */
+
+export const DEFAULT_PAGE_SIZE = 100;
+
+export async function* paginateOffset<T>(
+  fetchPage: (
+    offset: number,
+    limit: number,
+  ) => Promise<Record<string, unknown>>,
+  itemsKey: string,
+  pageSize: number = DEFAULT_PAGE_SIZE,
+): AsyncGenerator<T> {
+  let offset = 0;
+  for (;;) {
+    const page = await fetchPage(offset, pageSize);
+    const items = (page[itemsKey] as T[] | undefined) ?? [];
+    for (const item of items) {
+      yield item;
+    }
+    if (items.length < pageSize) {
+      return;
+    }
+    offset += pageSize;
+  }
+}
+
+export async function* paginateCursor<T>(
+  fetchPage: (cursor?: string) => Promise<Record<string, unknown>>,
+  itemsKey: string,
+): AsyncGenerator<T> {
+  let cursor: string | undefined;
+  for (;;) {
+    const page = await fetchPage(cursor);
+    const items = (page[itemsKey] as T[] | undefined) ?? [];
+    for (const item of items) {
+      yield item;
+    }
+    if (page.eof) {
+      return;
+    }
+    cursor = page.nextCursor as string | undefined;
+    if (!cursor) {
+      return;
+    }
+  }
+}

--- a/src/resources/events.ts
+++ b/src/resources/events.ts
@@ -1,5 +1,7 @@
+import { DEFAULT_PAGE_SIZE, paginateOffset } from '../pagination';
 import { APIResource } from '../resource';
 import type {
+  Event,
   EventsListParams,
   GetEventResponse,
   GetEventsResponse,
@@ -8,6 +10,21 @@ import type {
 export class Events extends APIResource {
   async list(params?: EventsListParams): Promise<GetEventsResponse> {
     return this.client.get('/v1/events', { query: params });
+  }
+
+  /** Iterate over all events across pages, fetching them lazily. */
+  iterate(
+    params?: EventsListParams,
+    pageSize: number = DEFAULT_PAGE_SIZE,
+  ): AsyncGenerator<Event> {
+    return paginateOffset<Event>(
+      (offset, limit) =>
+        this.client.get<Record<string, unknown>>('/v1/events', {
+          query: { ...params, limit, offset },
+        }),
+      'events',
+      pageSize,
+    );
   }
 
   async retrieve(id: number): Promise<GetEventResponse> {

--- a/src/resources/markets.ts
+++ b/src/resources/markets.ts
@@ -1,9 +1,11 @@
+import { DEFAULT_PAGE_SIZE, paginateOffset } from '../pagination';
 import { APIResource } from '../resource';
 import type {
   GetMarketResponse,
   GetMarketsResponse,
   MarketBBO,
   MarketBook,
+  MarketDetail,
   MarketSettlement,
   MarketsListParams,
 } from '../types';
@@ -11,6 +13,21 @@ import type {
 export class Markets extends APIResource {
   async list(params?: MarketsListParams): Promise<GetMarketsResponse> {
     return this.client.get('/v1/markets', { query: params });
+  }
+
+  /** Iterate over all markets across pages, fetching them lazily. */
+  iterate(
+    params?: MarketsListParams,
+    pageSize: number = DEFAULT_PAGE_SIZE,
+  ): AsyncGenerator<MarketDetail> {
+    return paginateOffset<MarketDetail>(
+      (offset, limit) =>
+        this.client.get<Record<string, unknown>>('/v1/markets', {
+          query: { ...params, limit, offset },
+        }),
+      'markets',
+      pageSize,
+    );
   }
 
   async retrieve(id: number): Promise<GetMarketResponse> {

--- a/src/resources/portfolio.ts
+++ b/src/resources/portfolio.ts
@@ -1,5 +1,7 @@
+import { paginateCursor } from '../pagination';
 import { APIResource } from '../resource';
 import type {
+  Activity,
   GetActivitiesParams,
   GetActivitiesResponse,
   GetUserPositionsParams,
@@ -23,5 +25,17 @@ export class Portfolio extends APIResource {
       query: params,
       authenticated: true,
     });
+  }
+
+  /** Iterate over all activities, following the cursor across pages. */
+  iterateActivities(params?: GetActivitiesParams): AsyncGenerator<Activity> {
+    return paginateCursor<Activity>(
+      (cursor) =>
+        this.client.get<Record<string, unknown>>('/v1/portfolio/activities', {
+          query: { ...params, ...(cursor ? { cursor } : {}) },
+          authenticated: true,
+        }),
+      'activities',
+    );
   }
 }

--- a/src/resources/series.ts
+++ b/src/resources/series.ts
@@ -1,13 +1,30 @@
+import { DEFAULT_PAGE_SIZE, paginateOffset } from '../pagination';
 import { APIResource } from '../resource';
 import type {
   GetSeriesListResponse,
   GetSeriesResponse,
   SeriesListParams,
+  Series as SeriesModel,
 } from '../types';
 
 export class Series extends APIResource {
   async list(params?: SeriesListParams): Promise<GetSeriesListResponse> {
     return this.client.get('/v1/series', { query: params });
+  }
+
+  /** Iterate over all series across pages, fetching them lazily. */
+  iterate(
+    params?: SeriesListParams,
+    pageSize: number = DEFAULT_PAGE_SIZE,
+  ): AsyncGenerator<SeriesModel> {
+    return paginateOffset<SeriesModel>(
+      (offset, limit) =>
+        this.client.get<Record<string, unknown>>('/v1/series', {
+          query: { ...params, limit, offset },
+        }),
+      'series',
+      pageSize,
+    );
   }
 
   async retrieve(id: number): Promise<GetSeriesResponse> {

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -30,6 +30,21 @@ describe('Pagination', () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
     });
 
+    test('terminates when page size is non-positive', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ events: [{ id: 1 }] }))
+        .mockResolvedValueOnce(jsonResponse({ events: [] }));
+      const client = new PolymarketUS();
+
+      const ids: number[] = [];
+      for await (const event of client.events.iterate(undefined, 0)) {
+        ids.push(event.id);
+      }
+
+      expect(ids).toEqual([1]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     test('stops on an empty page', async () => {
       mockFetch
         .mockResolvedValueOnce(

--- a/tests/pagination.test.ts
+++ b/tests/pagination.test.ts
@@ -1,0 +1,103 @@
+import { PolymarketUS } from '../src';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as jest.Mock;
+
+const TEST_SECRET_KEY = 'nWGxne/9WmC6hEr0kuwsxERJxWl7MmkZcDusAxyuf2A=';
+
+function jsonResponse(payload: unknown): Response {
+  return new Response(JSON.stringify(payload), { status: 200 });
+}
+
+describe('Pagination', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  describe('offset pagination', () => {
+    test('iterates until a short page', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ events: [{ id: 1 }, { id: 2 }] }))
+        .mockResolvedValueOnce(jsonResponse({ events: [{ id: 3 }] }));
+      const client = new PolymarketUS();
+
+      const ids: number[] = [];
+      for await (const event of client.events.iterate(undefined, 2)) {
+        ids.push(event.id);
+      }
+
+      expect(ids).toEqual([1, 2, 3]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('stops on an empty page', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({ markets: [{ id: 1 }, { id: 2 }] }),
+        )
+        .mockResolvedValueOnce(jsonResponse({ markets: [] }));
+      const client = new PolymarketUS();
+
+      const ids: number[] = [];
+      for await (const market of client.markets.iterate(undefined, 2)) {
+        ids.push(market.id);
+      }
+
+      expect(ids).toEqual([1, 2]);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('cursor pagination', () => {
+    test('follows the cursor until eof', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            activities: [{ type: 'ACTIVITY_TYPE_TRADE' }],
+            nextCursor: 'c1',
+            eof: false,
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            activities: [{ type: 'ACTIVITY_TYPE_TRANSFER' }],
+            eof: true,
+          }),
+        );
+      const client = new PolymarketUS({
+        keyId: 'k',
+        secretKey: TEST_SECRET_KEY,
+      });
+
+      const types: (string | undefined)[] = [];
+      for await (const activity of client.portfolio.iterateActivities()) {
+        types.push(activity.type);
+      }
+
+      expect(types).toEqual(['ACTIVITY_TYPE_TRADE', 'ACTIVITY_TYPE_TRANSFER']);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('stops when there is no next cursor', async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({
+          activities: [{ type: 'ACTIVITY_TYPE_TRADE' }],
+          nextCursor: '',
+          eof: false,
+        }),
+      );
+      const client = new PolymarketUS({
+        keyId: 'k',
+        secretKey: TEST_SECRET_KEY,
+      });
+
+      const types: (string | undefined)[] = [];
+      for await (const activity of client.portfolio.iterateActivities()) {
+        types.push(activity.type);
+      }
+
+      expect(types).toEqual(['ACTIVITY_TYPE_TRADE']);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
## summary
adds `iterate()` async generators that transparently walk all pages so callers no longer hand-roll cursor/offset logic:

- offset-paginated resources: `events.iterate()`, `markets.iterate()`, `series.iterate()` (page until a short page is returned).
- cursor-paginated feed: `portfolio.iterateActivities()` (follow `nextCursor` until `eof` or an empty cursor).
- shared helpers live in `src/pagination.ts` (`paginateOffset` / `paginateCursor`).

positions are intentionally not iterated (the endpoint returns the full set in one response).

## test plan
- [x] `pnpm lint` (biome)
- [x] `pnpm typecheck` / `pnpm build`
- [x] `pnpm test` (135 passed; new `tests/pagination.test.ts` covers offset paging until short/empty page and cursor paging until eof/no-next-cursor)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive client-side helpers and new optional APIs; existing `list`/`activities` calls are unchanged, with tests covering termination edge cases.
> 
> **Overview**
> Adds **lazy auto-pagination** so callers can stream full list results without manual `offset` / `cursor` loops.
> 
> New shared helpers in `src/pagination.ts`: **`paginateOffset`** (stops on a short or empty page; clamps non-positive page size) and **`paginateCursor`** (follows `nextCursor` until `eof` or missing cursor). **`events`**, **`markets`**, and **`series`** gain **`iterate(params?, pageSize?)`**; **`portfolio`** gains authenticated **`iterateActivities(params?)`**. README documents `for await` usage. **`tests/pagination.test.ts`** covers multi-page offset iteration, empty-page stop, and cursor/`eof` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa162c61bb370bff0eeb019f1dfd299c98b4a721. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->